### PR TITLE
chore(new): added new workflows

### DIFF
--- a/.github/workflows/update-confluence.yml
+++ b/.github/workflows/update-confluence.yml
@@ -1,62 +1,81 @@
-name: Update Confluence Page with Commits
+name: Update Confluence Changelog
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   update-confluence:
     runs-on: ubuntu-latest
     env:
-      CONFLUENCE_URL: https://airnewn.atlassian.net/wiki
-      PAGE_ID: 98308
-      SPACE_KEY: "~7120201888c3feda8740dea868d9a13920847a"
-      PAGE_TITLE: "Changelog Updates"
+      PAGE_ID: "98308" # replace with your actual page ID
 
     steps:
-      - name: Checkout repo
+      - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Generate commit table HTML
-        id: commits
+      - name: Generate Commit Table HTML
         run: |
-          echo "Generating HTML commit table..."
-          REPO_NAME="${{ github.repository }}"
-          echo "<table><tr><th>Module Name</th><th>Commit ID</th><th>Commit Message</th><th>Commit Date & Time</th></tr>" > table.html
-          git log -n 5 --pretty=format:"<tr><td>$REPO_NAME</td><td>%h</td><td>%s</td><td>%ad</td></tr>" --date=iso >> table.html
-          echo "</table>" >> table.html
+          echo '<table><tr><th>Module Name</th><th>Commit ID</th><th>Commit Message</th><th>Commit Date & Time</th></tr>' > commit_table.html
+          git log -n 5 --pretty=format:'<tr><td>${{ github.repository }}</td><td>%h</td><td>%s</td><td>%ad</td></tr>' --date=iso >> commit_table.html
+          echo '</table>' >> commit_table.html
+          TABLE_HTML=$(cat commit_table.html)
+          echo "TABLE_HTML<<EOF" >> $GITHUB_ENV
+          echo "$TABLE_HTML" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
-          # Convert table to escaped string for JSON
-          TABLE=$(jq -Rs '.' < table.html)
-          echo "table=$TABLE" >> $GITHUB_OUTPUT
-
-      - name: Get current page version
-        id: version
+      - name: Fetch Current Page Version
         run: |
           RESPONSE=$(curl -s -u "${{ secrets.CONFLUENCE_USERNAME }}:${{ secrets.CONFLUENCE_API_TOKEN }}" \
-            "$CONFLUENCE_URL/rest/api/content/$PAGE_ID?expand=version")
-          VERSION=$(echo "$RESPONSE" | jq '.version.number')
-          echo "version=$((VERSION + 1))" >> $GITHUB_OUTPUT
+            -H "Accept: application/json" \
+            "${{ secrets.CONFLUENCE_URL }}/rest/api/content/${PAGE_ID}?expand=version")
 
-      - name: Update Confluence page 
+          echo "API RESPONSE: $RESPONSE"
+
+          PAGE_VERSION=$(echo "$RESPONSE" | jq -r '.version.number')
+          echo "Current Page Version: $PAGE_VERSION"
+          echo "PAGE_VERSION=$PAGE_VERSION" >> $GITHUB_ENV
+
+      - name: Update Confluence Page
         run: |
-          TABLE=${{ steps.commits.outputs.table }}
-          VERSION=${{ steps.version.outputs.version }}
+          NEW_VERSION=$((PAGE_VERSION + 1))
 
-          echo "Updating Confluence page..."
-
-          curl -s -u "${{ secrets.CONFLUENCE_USERNAME }}:${{ secrets.CONFLUENCE_API_TOKEN }}" \
-            -X PUT "$CONFLUENCE_URL/rest/api/content/$PAGE_ID" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "id": "'"$PAGE_ID"'",
-              "type": "page",
-              "title": "'"$PAGE_TITLE"'",
-              "space": { "key": "'"$SPACE_KEY"'" },
-              "version": { "number": '"$VERSION"' },
-              "body": {
-                "storage": {
-                  "value": '"$TABLE"',
-                  "representation": "storage"
+          JSON_PAYLOAD=$(jq -n \
+            --arg id "$PAGE_ID" \
+            --arg title "Changelog Updates" \
+            --arg space_key "~7120201888c3feda8740dea868d9a13920847a" \
+            --arg value "$TABLE_HTML" \
+            --argjson version "$NEW_VERSION" \
+            '{
+              id: $id,
+              type: "page",
+              title: $title,
+              space: { key: $space_key },
+              version: { number: $version },
+              body: {
+                storage: {
+                  value: $value,
+                  representation: "storage"
                 }
               }
-            }'
+            }')
+
+          echo "📦 JSON Payload:"
+          echo "$JSON_PAYLOAD"
+
+          RESPONSE=$(curl -s -w "%{http_code}" -o response.txt -X PUT \
+            -u "${{ secrets.CONFLUENCE_USERNAME }}:${{ secrets.CONFLUENCE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "$JSON_PAYLOAD" \
+            "${{ secrets.CONFLUENCE_URL }}/rest/api/content/${PAGE_ID}")
+
+          STATUS=$(cat response.txt)
+          echo "Confluence Response: $STATUS"
+          
+          if [[ "$STATUS" != 200 ]]; then
+            echo "❌ Failed to update Confluence page."
+            cat response.txt
+            exit 1
+          fi
+


### PR DESCRIPTION
<!--
IMPORTANT:

This repository contains configuration for what users see when they click on the `Actions` tab and the setup page for Code Scanning.

It is not:
* A playground to try out scripts
* A place for you to create a workflow for your repository
-->

## Pre-requisites

- [ ] Prior to submitting a new workflow, please apply to join the GitHub Technology Partner Program: [partner.github.com/apply](https://partner.github.com/apply?partnershipType=Technology+Partner).

---

### **Please note that at this time we are only accepting new starter workflows for Code Scanning. Updates to existing starter workflows are fine.**

---

## Tasks

**For _all_ workflows, the workflow:**

- [ ] Should be contained in a `.yml` file with the language or platform as its filename, in lower, [_kebab-cased_](https://en.wikipedia.org/wiki/Kebab_case) format (for example, [`docker-image.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml)).  Special characters should be removed or replaced with words as appropriate (for example, "dotnet" instead of ".NET").
- [ ] Should use sentence case for the names of workflows and steps (for example, "Run tests").
- [ ] Should be named _only_ by the name of the language or platform (for example, "Go", not "Go CI" or "Go Build").
- [ ] Should include comments in the workflow for any parts that are not obvious or could use clarification.
- [ ] Should specify least privileged [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for `GITHUB_TOKEN` so that the workflow runs successfully.

**For _CI_ workflows, the workflow:**

- [ ] Should be preserved under [the `ci` directory](https://github.com/actions/starter-workflows/tree/main/ci).
- [ ] Should include a matching `ci/properties/*.properties.json` file (for example, [`ci/properties/docker-publish.properties.json`](https://github.com/actions/starter-workflows/blob/main/ci/properties/docker-publish.properties.json)).
- [ ] Should run on `push` to `branches: [ $default-branch ]` and `pull_request` to `branches: [ $default-branch ]`.
- [ ] Packaging workflows should run on `release` with `types: [ created ]`.
- [ ] Publishing workflows should have a filename that is the name of the language or platform, in lower case, followed by "-publish" (for example, [`docker-publish.yml`](https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml)).

**For _Code Scanning_ workflows, the workflow:**

- [ ] Should be preserved under [the `code-scanning` directory](https://github.com/actions/starter-workflows/tree/main/code-scanning).
- [ ] Should include a matching `code-scanning/properties/*.properties.json` file (for example, [`code-scanning/properties/codeql.properties.json`](https://github.com/actions/starter-workflows/blob/main/code-scanning/properties/codeql.properties.json)), with properties set as follows:
  - [ ] `name`: Name of the Code Scanning integration.
  - [ ] `creator`: Name of the organization/user producing the Code Scanning integration.
  - [ ] `description`: Short description of the Code Scanning integration.
  - [ ] `categories`: Array of languages supported by the Code Scanning integration.
  - [ ] `iconName`: Name of the SVG logo representing the Code Scanning integration. This SVG logo must be present in [the `icons` directory](https://github.com/actions/starter-workflows/tree/main/icons).
- [ ] Should run on `push` to `branches: [ $default-branch, $protected-branches ]` and `pull_request` to `branches: [ $default-branch ]`. We also recommend a `schedule` trigger of `cron: $cron-weekly` (for example, [`codeql.yml`](https://github.com/actions/starter-workflows/blob/c59b62dee0eae1f9f368b7011cf05c2fc42cf084/code-scanning/codeql.yml#L14-L21)).

**Some general notes:**

- [ ] This workflow must _only_ use actions that are produced by GitHub, [in the `actions` organization](https://github.com/actions), **or**
- [ ] This workflow must _only_ use actions that are produced by the language or ecosystem that the workflow supports.  These actions must be [published to the GitHub Marketplace](https://github.com/marketplace?type=actions).  We require that these actions be referenced using the full 40 character hash of the action's commit instead of a tag.  Additionally, workflows must include the following comment at the top of the workflow file:
    ```
    # This workflow uses actions that are not certified by GitHub.
    # They are provided by a third-party and are governed by
    # separate terms of service, privacy policy, and support
    # documentation.
    ```
- [ ] Automation and CI workflows should not send data to any 3rd party service except for the purposes of installing dependencies.
- [ ] Automation and CI workflows cannot be dependent on a paid service or product.
